### PR TITLE
Added method for changing client's team using L4DTeam

### DIFF
--- a/sourcemod/scripting/include/left4dhooks_stocks.inc
+++ b/sourcemod/scripting/include/left4dhooks_stocks.inc
@@ -209,6 +209,18 @@ stock L4DTeam L4D_GetClientTeam(int client)
 }
 
 /**
+ * Changes the client's team using L4DTeam.
+ *
+ * @param client		Player's index.
+ * @return				New L4DTeam of player.
+ * @error				Invalid client index.
+ */
+stock void L4D_ChangeClientTeam(int client, L4DTeam team)
+{
+	ChangeClientTeam(client, view_as<int>(team));
+}
+
+/**
  * Returns zombie player L4D1 zombie class.
  *
  * @param client		Player's index.


### PR DESCRIPTION
In `clients.inc`, there is a `native void ChangeClientTeam(int client, int team);` which accepts an integer. 
To make the dev experience easier (and also to make some of the plugins that were made for me compile without having to figure out which team is what integer), adding a new method that accepts the `L4DTeam` enum.

Hopefully this would make some dev experience "easier" sometimes.