### PR TITLE
Fix `Ammo_t.GetName` & Add `AmmoDef.MaxCarry_Call`

### DIFF
--- a/sourcemod/gamedata/left4dhooks.l4d1.txt
+++ b/sourcemod/gamedata/left4dhooks.l4d1.txt
@@ -1771,6 +1771,12 @@
 				*/
 				"linux" "68"
 			}
+
+			"CAmmoDef::MaxCarry"
+			{
+				"linux"		"0"
+				"windows"	"0"
+			}
 		}
 
 

--- a/sourcemod/gamedata/left4dhooks.l4d2.txt
+++ b/sourcemod/gamedata/left4dhooks.l4d2.txt
@@ -2768,6 +2768,12 @@
 				"linux"		"340"
 				"windows"	"340"
 			}
+
+			"CAmmoDef::MaxCarry"
+			{
+				"linux"		"0"
+				"windows"	"0"
+			}
 		}
 
 

--- a/sourcemod/scripting/include/left4dhooks.inc
+++ b/sourcemod/scripting/include/left4dhooks.inc
@@ -1199,11 +1199,24 @@ methodmap AmmoDef
 
 	/**
 	 * @brief Retrieves the maximum ammo that a player can carry
+	 * @note Returns the value locally calculated using Ammo_t.
 	 *
 	 * @param nAmmoIndex	Ammo index
 	 * @return				Ammo count
 	 */
 	public static native int MaxCarry(int nAmmoIndex);
+
+	/**
+	 * @brief Retrieves the maximum ammo that a player can carry
+	 * @note Returns the value from the function call.
+	 * @note Recommended to use this one in order to get values modified by others plugins.
+	 *
+	 * @param nAmmoIndex	Ammo index
+	 * @param client		Client index to test.
+	 * 						Has no actual effect in function, but helps identify who is picking up ammo.
+	 * @return				Ammo count
+	 */
+	public static native int MaxCarry_Call(int nAmmoIndex, int client = -1);
 
 	public static native int PlrDamage(int nAmmoIndex);
 	public static native int NPCDamage(int nAmmoIndex);

--- a/sourcemod/scripting/l4dd/l4dd_gamedata.sp
+++ b/sourcemod/scripting/l4dd/l4dd_gamedata.sp
@@ -1196,6 +1196,19 @@ void LoadGameData()
 			LogError("Failed to create SDKCall: \"KeyValues::GetString\" (%s)", g_sSystem);
 	}
 
+	StartPrepSDKCall(SDKCall_Raw);
+	if( PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CAmmoDef::MaxCarry") == false )
+	{
+		LogError("Failed to find signature: \"CAmmoDef::MaxCarry\" (%s)", g_sSystem);
+	} else {
+		PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+		PrepSDKCall_AddParameter(SDKType_CBasePlayer, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
+		PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+		g_hSDK_AmmoDef_MaxCarry = EndPrepSDKCall();
+		if( g_hSDK_AmmoDef_MaxCarry == null )
+			LogError("Failed to create SDKCall: \"CAmmoDef::MaxCarry\" (%s)", g_sSystem);
+	}
+
 	if( g_bLeft4Dead2 )
 	{
 		StartPrepSDKCall(SDKCall_GameRules);

--- a/sourcemod/scripting/l4dd/l4dd_natives.sp
+++ b/sourcemod/scripting/l4dd/l4dd_natives.sp
@@ -6107,9 +6107,10 @@ void Ammo_t_CreateNatives()
 any Native_Ammo_t_GetName(Handle plugin, int numParams)
 {
 	Address pThis = GetNativeCell(1);
+	Address pName = LoadFromAddress(pThis, NumberType_Int32);
 
 	char name[MAX_NAME_LENGTH];
-	L4D_ReadMemoryString(pThis, name, sizeof(name));
+	L4D_ReadMemoryString(pName, name, sizeof(name));
 
 	SetNativeString(2, name, GetNativeCell(3));
 	return 0;

--- a/sourcemod/scripting/l4dd/l4dd_natives.sp
+++ b/sourcemod/scripting/l4dd/l4dd_natives.sp
@@ -94,6 +94,7 @@ Handle g_hSDK_Checkpoint_ContainsArea;
 Handle g_hSDK_CTerrorGameRules_GetNumChaptersForMissionAndMode;
 Handle g_hSDK_CDirector_GetGameModeBase;
 Handle g_hSDK_KeyValues_GetString;
+Handle g_hSDK_AmmoDef_MaxCarry;
 
 // left4downtown.inc
 Handle g_hSDK_CTerrorGameRules_GetTeamScore;
@@ -6287,6 +6288,7 @@ void AmmoDef_CreateNatives()
 	CreateNative("AmmoDef.PlrDamage", Native_AmmoDef_PlrDamage);
 	CreateNative("AmmoDef.NPCDamage", Native_AmmoDef_NPCDamage);
 	CreateNative("AmmoDef.MaxCarry", Native_AmmoDef_MaxCarry);
+	CreateNative("AmmoDef.MaxCarry_Call", Native_AmmoDef_MaxCarry_Call);
 	CreateNative("AmmoDef.DamageType", Native_AmmoDef_DamageType);
 	CreateNative("AmmoDef.Flags", Native_AmmoDef_Flags);
 	CreateNative("AmmoDef.MinSplashSize", Native_AmmoDef_MinSplashSize);
@@ -6395,6 +6397,21 @@ any Native_AmmoDef_MaxCarry(Handle plugin, int numParams)
 	{
 		return AmmoDef_m_AmmoType(nAmmoIndex).pMaxCarry;
 	}
+}
+
+any Native_AmmoDef_MaxCarry_Call(Handle plugin, int numParams)
+{
+	ValidateAddress(g_pAmmoDef, "AmmoDef");
+
+	int nAmmoIndex = GetNativeCell(1);
+	int client = GetNativeCell(2);
+
+	// "nAmmoIndex" left unchecked because it's done in the called function
+	if (client <= 0 || client > MaxClients)
+		client = -1;
+	
+	//PrintToServer("#### CALL g_hSDK_AmmoDef_MaxCarry");
+	return SDKCall(g_hSDK_AmmoDef_MaxCarry, g_pAmmoDef, nAmmoIndex, client);
 }
 
 any Native_AmmoDef_DamageType(Handle plugin, int numParams)

--- a/sourcemod/scripting/left4dhooks_test.sp
+++ b/sourcemod/scripting/left4dhooks_test.sp
@@ -361,6 +361,37 @@ Action sm_l4dd(int client, int args)
 	*/
 
 
+	/*
+	for (int i = AmmoDef.GetAmmoIndex()-1; i > 0; --i)
+	{
+		char name[64];
+		Ammo_t ammo = AmmoDef.GetAmmoOfIndex(i);
+		ammo.GetName(name, sizeof(name));
+		ReplyToCommand(client, "Ammo_t#%d (%s)", i, name);
+	}
+
+	if (client > 0)
+	{
+		int weapon = GetPlayerWeaponSlot(client, 0);
+		if (weapon != -1)
+		{
+			int index = GetEntProp(weapon, Prop_Send, "m_iPrimaryAmmoType");
+
+			char name[64];
+			Ammo_t ammo = AmmoDef.GetAmmoOfIndex(index);
+			ammo.GetName(name, sizeof(name));
+
+			ReplyToCommand(client, "primary ammotype (#%d) (%s)", index, name);
+
+			ReplyToCommand(client, "primary MaxCarry (%d)", AmmoDef.MaxCarry(index));
+			ReplyToCommand(client, "primary MaxCarry (%d)", AmmoDef.MaxCarry(index));
+
+			ReplyToCommand(client, "primary MaxCarry_Call (%d)", AmmoDef.MaxCarry_Call(index, -1));			// ok
+			ReplyToCommand(client, "primary MaxCarry_Call (%d)", AmmoDef.MaxCarry_Call(index, client));		// ok
+			// ReplyToCommand(client, "primary MaxCarry_Call (%d)", AmmoDef.MaxCarry_Call(index, 0););		// error, invalid client index 0 (thrown by SDKCall)
+		}
+	}
+	*/
 
 	/*
 	L4D_SetPlayerIntensity(client, 0.9);


### PR DESCRIPTION
Fix:
- Fixed `Ammo_t.GetName` reading wrong address.

Feature:
- Added `AmmoDef.MaxCarry_Call` to retrieve values potentially modified by other plugins (via hooks on `ammodef`).

Added test cases.