### PR TITLE
Fix an old inconsistency in the native 'L4D2Direct_GetSpawnTimer'.

### DIFF
--- a/sourcemod/scripting/include/left4dhooks.inc
+++ b/sourcemod/scripting/include/left4dhooks.inc
@@ -6766,17 +6766,17 @@ native float L4D2Direct_GetMapMaxFlowDistance();
 /* CTerrorPlayer Variable access */
 
 /**
- * Get a reference to a CountdownTimer that tracks when an SI player can next spawn
+ * Get the value of "CTerrorPlayer::m_flBecomeGhostAt", which tracks the next time the SI player will spawn
  * @note The duration of this timer is controlled by the cvars z_ghost_delay_min and z_ghost_delay_max
  * @remarks It is advised to use the "L4D_GetPlayerSpawnTime" native instead of this
  *
  * @param client		Client id to get the spawn timer for
  *
- * @return				CountdownTimer reference to the timer, or CTimer_Null on lookup failure
+ * @return				Time (seconds) until the SI will spawn, or -1.0 in case of error
  * @error				Invalid client
  */
 // L4D2 only
-native CountdownTimer L4D2Direct_GetSpawnTimer(int client);
+native float L4D2Direct_GetSpawnTimer(int client);
 
 /**
  * Get a reference to a CountdownTimer that tracks when an survivor player is invulnerable due to "godframes"

--- a/sourcemod/scripting/l4dd/l4dd_natives.sp
+++ b/sourcemod/scripting/l4dd/l4dd_natives.sp
@@ -4270,13 +4270,9 @@ any Direct_GetSpawnTimer(Handle plugin, int numParams) // Native "L4D2Direct_Get
 
 	int client = GetNativeCell(1);
 	if( client < 1 || client > MaxClients )
-		return CTimer_Null;
+		return -1.0;
 
-	Address pEntity = GetEntityAddress(client);
-	if( pEntity == Address_Null )
-		return CTimer_Null;
-
-	return view_as<CountdownTimer>(pEntity + view_as<Address>(g_iOff_m_flBecomeGhostAt - 8));
+	return view_as<float>(GetEntDataFloat(client, g_iOff_m_flBecomeGhostAt));
 }
 
 any Direct_GetInvulnerabilityTimer(Handle plugin, int numParams) // Native "L4D2Direct_GetInvulnerabilityTimer"

--- a/sourcemod/scripting/left4dhooks_test.sp
+++ b/sourcemod/scripting/left4dhooks_test.sp
@@ -719,7 +719,7 @@ Action sm_l4dd(int client, int args)
 	// PrintToChatAll("Old spawn time: %f", L4D_GetPlayerSpawnTime(client));
 	// L4D_SetPlayerSpawnTime(client, 25.0, false);
 	// PrintToChatAll("New spawn time: %f", L4D_GetPlayerSpawnTime(client));
-	// PrintToChatAll("Direct_GetSpawnTimer %f", CTimer_GetElapsedTime(L4D2Direct_GetSpawnTimer(client)));
+	// PrintToChatAll("Direct_GetSpawnTimer %f", L4D2Direct_GetSpawnTimer(client));
 
 
 
@@ -2172,7 +2172,6 @@ Action sm_l4dd(int client, int args)
 		PrintToServer("Direct_GetVSStartTimer address %d",					L4D2Direct_GetVSStartTimer());
 		PrintToServer("Direct_GetScavengeRoundSetupTimer address %d",		L4D2Direct_GetScavengeRoundSetupTimer());
 		PrintToServer("Direct_GetScavengeOvertimeGraceTimer address %d",	L4D2Direct_GetScavengeOvertimeGraceTimer());
-		PrintToServer("Direct_GetSpawnTimer address %d",					L4D2Direct_GetSpawnTimer(client));
 		PrintToServer("Direct_GetShovePenalty %d",							L4D2Direct_GetShovePenalty(client)); // Seems working
 		L4D2Direct_SetShovePenalty(client, 50);
 		PrintToServer("Direct_SetShovePenalty %d",							L4D2Direct_GetShovePenalty(client));


### PR DESCRIPTION
This commit will force people to update their plugin code, as using this native feature incorrectly can break game data and cause bugs. It's been clear for a long time that it's not a countdowntimer, but a simple float, but if you don't update the code, the problems will persist.