### PR TITLE
Add int weapon attribute "AmmoType"

### DIFF
--- a/sourcemod/gamedata/left4dhooks.l4d1.txt
+++ b/sourcemod/gamedata/left4dhooks.l4d1.txt
@@ -1754,6 +1754,11 @@
 				"windows"	"2196"
 				"linux"		"2196"
 			}
+			"L4D2IntWeapon_AmmoType"
+			{
+				"windows"	"1808"
+				"linux"		"1808"
+			}
 
 			// L4D2FloatWeapon
 			"L4D2FloatWeapon_MaxPlayerSpeed"

--- a/sourcemod/gamedata/left4dhooks.l4d2.txt
+++ b/sourcemod/gamedata/left4dhooks.l4d2.txt
@@ -2750,6 +2750,11 @@
 				"windows"	"2196"
 				"linux"		"2196"
 			}
+			"L4D2IntWeapon_AmmoType"
+			{
+				"windows"	"2128"
+				"linux"		"2128"
+			}
 
 			// L4D2FloatWeapon
 			"L4D2FloatWeapon_MaxPlayerSpeed"

--- a/sourcemod/scripting/include/left4dhooks.inc
+++ b/sourcemod/scripting/include/left4dhooks.inc
@@ -6818,6 +6818,7 @@ enum L4D2IntWeaponAttributes
 	L4D2IWA_Tier, // L4D2 only
 	L4D2IWA_DefaultSize, // Default weapon clip size
 	L4D2IWA_WeaponType, // Can use with the "WeaponType" enum
+	L4D2IWA_AmmoType,
 	MAX_SIZE_L4D2IntWeaponAttributes
 };
 

--- a/sourcemod/scripting/l4dd/l4dd_gamedata.sp
+++ b/sourcemod/scripting/l4dd/l4dd_gamedata.sp
@@ -3057,6 +3057,7 @@ void LoadGameData()
 	L4D2IntWeapon_Offsets[4] = hGameData.GetOffset("L4D2IntWeapon_Tier");
 	L4D2IntWeapon_Offsets[5] = hGameData.GetOffset("L4D2IntWeapon_DefaultSize");
 	L4D2IntWeapon_Offsets[6] = hGameData.GetOffset("L4D2IntWeapon_Type");
+	L4D2IntWeapon_Offsets[7] = hGameData.GetOffset("L4D2IntWeapon_AmmoType");
 	L4D2FloatWeapon_Offsets[0] = hGameData.GetOffset("L4D2FloatWeapon_MaxPlayerSpeed");
 	L4D2FloatWeapon_Offsets[1] = hGameData.GetOffset("L4D2FloatWeapon_SpreadPerShot");
 	L4D2FloatWeapon_Offsets[2] = hGameData.GetOffset("L4D2FloatWeapon_MaxSpread");

--- a/sourcemod/scripting/left4dhooks.sp
+++ b/sourcemod/scripting/left4dhooks.sp
@@ -341,7 +341,7 @@ int L4D2CountdownTimer_Offsets[10];
 int L4D2IntervalTimer_Offsets[6];
 
 // l4d2weapons.inc
-int L4D2IntWeapon_Offsets[7];
+int L4D2IntWeapon_Offsets[8];
 int L4D2FloatWeapon_Offsets[21];
 int L4D2BoolMeleeWeapon_Offsets[1];
 int L4D2IntMeleeWeapon_Offsets[2];

--- a/sourcemod/scripting/left4dhooks_test.sp
+++ b/sourcemod/scripting/left4dhooks_test.sp
@@ -362,6 +362,11 @@ Action sm_l4dd(int client, int args)
 
 
 
+	// L4D2IWA_AmmoType
+	/*
+	int ammotype = L4D2_GetIntWeaponAttribute("weapon_pistol", L4D2IWA_AmmoType);
+	PrintToServer("[%s] L4D2IWA_AmmoType (%d) ", "weapon_pistol", ammotype);
+	*/
 
 	/*
 	float vPos[3], vLoc[3];


### PR DESCRIPTION
For acquiring the weapon's primary ammo type, while the secondary one is untouched since it's never in use.